### PR TITLE
Require minimum bison version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0.2)
 project(never)
 enable_language(C)
 
-find_package(BISON)
+find_package(BISON 2.7.1)
 find_package(FLEX)
 BISON_TARGET(parser ${CMAKE_CURRENT_SOURCE_DIR}/front/parser.y ${CMAKE_CURRENT_SOURCE_DIR}/front/parser.c VERBOSE parser.txt)
 FLEX_TARGET(scanner ${CMAKE_CURRENT_SOURCE_DIR}/front/scanner.l  ${CMAKE_CURRENT_SOURCE_DIR}/front/scanner.c)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0.2)
 enable_language(C)
 
 if (MSVC)


### PR DESCRIPTION
In `cmake` file add minimum required version for bison.
Also upgrade minimum `cmake` version for tests (2.8 is deprecated).